### PR TITLE
Update readme(Install latest version)

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -9,7 +9,7 @@ myprofiler は MySQL のサンプリングプロファイラです。
 tarball をダウンロードして展開し、実行ファイルを PATH が通ったディレクトリに配置します。
 
 ```console
-wget https://github.com/KLab/myprofiler/releases/download/0.1/myprofiler.linux_amd64.tar.gz
+wget https://github.com/KLab/myprofiler/releases/download/0.2/myprofiler.linux_amd64.tar.gz
 tar xf myprofiler.linux_amd64.tar.gz
 mv myprofiler ~/bin
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It watches `SHOW FULL PROCESSLIST` periodically, and count each query.
 Download archive and put it on directory in your PATH.
 
 ```console
-wget https://github.com/KLab/myprofiler/releases/download/0.1/myprofiler.linux_amd64.tar.gz
+wget https://github.com/KLab/myprofiler/releases/download/0.2/myprofiler.linux_amd64.tar.gz
 tar xf myprofiler.linux_amd64.tar.gz
 mv myprofiler ~/bin
 ```


### PR DESCRIPTION
## Why
Right now, in Install process of `README.md` instructs us to install **version 0.1** like below:

```
wget https://github.com/KLab/myprofiler/releases/download/0.1/myprofiler.linux_amd64.tar.gz
tar xf myprofiler.linux_amd64.tar.gz
mv myprofiler ~/bin
```
However, according to [the release info](https://github.com/KLab/myprofiler/releases) the latest version is **0.2**.

It'll cause confusion, so I'd like to update README.


## What
I've changed README.

