### PR TITLE
Feature: supply the MySQL password using `MYSQL_PWD` env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Usage of ./myprofiler:
   -dump="": Write raw queries to this file
   -host="localhost": Host of database
   -interval=1: (float) Sampling interval
-  -password="": Password
+  -password="": Password - Can also be supplied using environment variable `MYSQL_PWD`
   -port=3306: Port
   -last=0: (int) Last N samples are summarized. 0 means summarize all samples
   -top=10: (int) Show N most common queries

--- a/myprofiler.go
+++ b/myprofiler.go
@@ -224,7 +224,7 @@ func main() {
 	cfg := Config{}
 	flag.StringVar(&host, "host", "localhost", "Host of database")
 	flag.StringVar(&dbuser, "user", dbuser, "User")
-	flag.StringVar(&password, "password", "", "Password")
+	flag.StringVar(&password, "password", os.Getenv("MYSQL_PWD"), "Password")
 	flag.IntVar(&port, "port", 3306, "Port")
 
 	flag.StringVar(&dumpfile, "dump", "", "Write raw queries to this file")


### PR DESCRIPTION
The purpose is to keep the password out of the Linux process list.
The [MySQL Manual](https://dev.mysql.com/doc/refman/5.7/en/password-security-user.html) explains this can also be insecure. During my testing only the `root` user and the process owner were able to view the enviroment variables using `ps aue`. This is a lot more secure than having the password in cleartext in the process list.